### PR TITLE
Use '502 Bad Gateway' as a general proxy server error

### DIFF
--- a/src/main/scala/com/karasiq/proxy/server/ProxyConnectionRequest.scala
+++ b/src/main/scala/com/karasiq/proxy/server/ProxyConnectionRequest.scala
@@ -34,7 +34,7 @@ object ProxyConnectionRequest {
   def failureResponse(request: ProxyConnectionRequest): ByteString = {
     request.scheme match {
       case "http" | "https" ⇒
-        HttpResponse((HttpStatus(400, "Bad Request"), Nil))
+        HttpResponse((HttpStatus(502, "Bad Gateway"), Nil))
 
       case "socks" | "socks5" ⇒
         ConnectionStatusResponse(SocksV5, None, Codes.failure(SocksV5))


### PR DESCRIPTION
`502 Bad Gateway` might be a better status code than currently used `400 Bad Request` for indicating a general proxy server error, especially when an upstream proxy is used. `400 Bad Request` implies that HTTP proxy client made a mistake in the request itself. For instance, a quote from Wikipedia,

> 400 Bad Request
>
> The server cannot or will not process the request due to an apparent client error (e.g., malformed request syntax, size too large, invalid request message framing, or deceptive request routing).

> 502 Bad Gateway
>
> The server was acting as a gateway or proxy and received an invalid response from the upstream server.